### PR TITLE
regional MSD and get_diffusivity_from_msd

### DIFF
--- a/pymatgen/analysis/diffusion/aimd/rdf.py
+++ b/pymatgen/analysis/diffusion/aimd/rdf.py
@@ -103,13 +103,10 @@ class RadialDistributionFunction:
                 for j in range(len(r) ** 3)
                 if indices[u] != reference_indices[v] or j != indx0
             ]
-            r_indices = [int(dist / dr) for dist in filter(lambda e: e < rmax + 1e-8, dists)]
+            r_indices = [int(dist / dr) for dist in filter(lambda e: e < rmax, dists)]
             dns.update(r_indices)
 
         for indx, dn in dns.most_common(ngrid):
-            if indx > len(interval) - 1:
-                continue
-
             # Volume of the thin shell
             ff = 4.0 / 3.0 * np.pi * (interval[indx + 1] ** 3 - interval[indx] ** 3)
             # print(norm.pdf(interval, interval[indx], sigma) * dn /


### PR DESCRIPTION
Two major changes to the diffusion analyzer:

1. **Added the optional analysis of regional MSD, regional diffusivity and regional conductivity.** 
The region is defined by the argument of `c_ranges`, which is a list of fractional ranges of z-axis. The start and end positions of ion displacements in each time interval are evaluated, and only those ion displacements inside the `c_ranges` are included in regional MSD.
2.  **A new function named `get_diffusivity_from_msd`.** 
Diffusivity is calculated from linear regression on MSD and dt. Previously, this analysis was done to MSD (`msd`), partial MSD (`msd_component`) and charge displacements (`mscd`) with some repetitive codes in the `__init__` constructor. Now, this analysis is isolated to a function named `get_diffusivity_from_msd` so that the repetitive code is gone. More importantly, users now can do diffusivity analysis directly with MSD data, and trajectory structures are not compulsory any more.

All previous tests are passed. In future, new tests and examples on regional MSD and regional diffusivity can be included.