### PR TITLE
Fix breaking change from pymatgen

### DIFF
--- a/pymatgen/analysis/diffusion/utils/parse_entries.py
+++ b/pymatgen/analysis/diffusion/utils/parse_entries.py
@@ -262,7 +262,7 @@ def get_sym_migration_ion_sites(
     sym_migration_struct = Structure.from_sites(sym_migration_ion_sites)
     for op in sa.get_space_group_operations():
         struct_tmp = sym_migration_struct.copy()
-        struct_tmp.apply_operation(symmop=op, fractional=True)
+        struct_tmp.apply_operation(op, fractional=True)
         for isite in struct_tmp.sites:
             if isite.species_string == wi_:
                 sym_migration_struct.insert(


### PR DESCRIPTION
In pymatgen PR [3790](https://github.com/materialsproject/pymatgen/pull/3790), the only required arg of `Structure.apply_operation` was renamed from `symmop` to `symm_op`. As this arg was specified explicitly in `pymatgen.analysis.diffusion.utils.parse_entries.get_sym_migration_ion_sites`, I've removed the explicit argname from the call to `apply_operation` (this fix will still work even if the breaking change is undone).

Noticed in downstream code (emmet) where tests broke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the conciseness of method calls in the diffusion analysis tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->