### PR TITLE
Exponential fitting mode for Arrhenius fit

### DIFF
--- a/pymatgen/analysis/diffusion/tests/test_analyzer.py
+++ b/pymatgen/analysis/diffusion/tests/test_analyzer.py
@@ -38,10 +38,16 @@ class FuncTest(PymatgenTest):
         temps = np.array([300, 1000, 500])
         diffusivities = c * np.exp(-Ea / (k * temps))
         diffusivities *= np.array([1.00601834013, 1.00803236262, 0.98609720824])
+
         r = fit_arrhenius(temps, diffusivities)
         self.assertAlmostEqual(r[0], Ea)
         self.assertAlmostEqual(r[1], c)
         self.assertAlmostEqual(r[2], 0.000895566)
+
+        r = fit_arrhenius(temps, diffusivities, mode="exp", diffusivity_errors=diffusivities * 0.01)
+        self.assertAlmostEqual(r[0], Ea, 5)
+        self.assertAlmostEqual(r[1], c, 2)
+        self.assertAlmostEqual(r[2], 0.000904815)
 
         # when not enough values for error estimate
         r2 = fit_arrhenius([1, 2], [10, 10])
@@ -51,6 +57,11 @@ class FuncTest(PymatgenTest):
 
         ax = get_arrhenius_plot(temps, diffusivities)
         assert isinstance(ax, mpl.axes.Axes)
+
+        ax = get_arrhenius_plot(temps, diffusivities, mode="exp", diffusivity_errors=diffusivities * 0.01, unit="eV")
+        assert isinstance(ax, mpl.axes.Axes)
+        assert ax.get_xlabel() == "T (K)"
+        assert ax.get_ylabel() == "D (cm$^2$/s)"
 
 
 class DiffusionAnalyzerTest(PymatgenTest):


### PR DESCRIPTION
## Summary

Major changes:

- Implemented an exponential fitting mode for the Arrhenius fit. We found this to be beneficial for obtaining a more reliable estimate of the activation enthalpy in case the diffusivities at low temperature are affected by large error, i.e. the errors do not appear homoscedastic in the linear representation anymore. More context can be found e.g. at https://pubs.acs.org/doi/full/10.1021/acs.jchemed.3c00466

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
